### PR TITLE
fix: setRoutingUnits to allow 0 decimal

### DIFF
--- a/src/lib/common/routing/routing.ts
+++ b/src/lib/common/routing/routing.ts
@@ -74,7 +74,7 @@ export function SetRoutingUnits(routing: Routing, token: BridgeToken | undefined
     if (!token) throw new Error("Token not defined");
     if (routing.units) return;
     if (!routing.amount) throw new Error("Routing amount not defined");
-    if (!token.decimals) throw new Error("Routing decimals not defined");
+    if (token.decimals == undefined) throw new Error("Routing decimals not defined");
 
     routing.units = ValueUnits.fromValue(routing.amount, token.decimals).units.toString();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "lib": [
       // ... other libs
-      "ES2021.String",
+      "ES2021",
       "dom"
     ],
     "resolveJsonModule": true,


### PR DESCRIPTION
I've noticed the func in charge of setting routing units will error in the case of a 0 decimal token. Since there are many 0 decimals tokens on Algorand I don't think this is the intended behavior.

I'm not familiar enough with this repo to know if this will cause a regression and I don't see any test for that func in particular. Feel free to merge or close.